### PR TITLE
Use Optional type hint for Python < 3.10 compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
+from typing import Optional  
 from time import sleep
 from tqdm import tqdm
 import json
@@ -55,7 +56,7 @@ class LeccapDownloader:
         ):
             sleep(1.0)
 
-    def find_course_link(self) -> WebElement | None:
+    def find_course_link(self) -> Optional[WebElement]:  
         print("[i] Searching for course...")
         self.goto_home()
         by_year_link = self.driver.find_element(


### PR DESCRIPTION
Description:
The current code uses the `|` union type syntax which was introduced in Python 3.10.
This causes a TypeError in earlier Python versions:
`TypeError: unsupported operand type(s) for |: 'ABCMeta' and 'NoneType'`

Proposed fix:
Replace `WebElement | None` with `Optional[WebElement]` for broader version compatibility.

Changes:
- Added `from typing import Optional` import
- Changed return type annotation from `WebElement | None` to `Optional[WebElement]`
- Maintains same functionality while supporting Python < 3.10

Testing:
- Tested on Python 3.9.19
- Functionality remains identical
- Type checking passes